### PR TITLE
Expose functions to layout

### DIFF
--- a/html.go
+++ b/html.go
@@ -57,7 +57,7 @@ func (h *HTML) Load(names ...string) error {
 			return err
 		}
 
-		h.layout, err = template.New("").Parse(string(b))
+		h.layout, err = template.New("").Funcs(h.funcMap).Parse(string(b))
 		if err != nil {
 			return errors.Wrap(err, "failed to load layout template")
 		}

--- a/html_test.go
+++ b/html_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRenderer(t *testing.T) {
-	r := New("/auth")
+	r := NewHTML("/auth", ".")
 
 	err := r.Load("login")
 	if err != nil {


### PR DESCRIPTION
Hi @aarondl 

This tiny patch exposes the helper functions [(`title` and `mountpathed`)](https://github.com/volatiletech/authboss-renderer/blob/master/html.go#L38-L46), currently only exported to views, also to the layout.

Closes https://github.com/volatiletech/authboss-renderer/issues/1