### PR TITLE
Fix for the <a> tag in recover_html.tpl

### DIFF
--- a/email-templates/recover_html.tpl
+++ b/email-templates/recover_html.tpl
@@ -1,3 +1,3 @@
 <h1>Recover your account</h1>
 <br />
-<p>Please click <a href="{{.recover_url}}" />here</a> to recover your account</p>
+<p>Please click <a href="{{.recover_url}}">here</a> to recover your account</p>


### PR DESCRIPTION
This fixes the broken link in the HTML template for the Recover email.